### PR TITLE
Give permission to access namespaces

### DIFF
--- a/deploy/leaf-hub-status-sync.yaml.template
+++ b/deploy/leaf-hub-status-sync.yaml.template
@@ -50,11 +50,6 @@ rules:
   - ""
   resources:
   - namespaces
-  verbs:
-  - create
-- apiGroups:
-  - ""
-  resources:
   - pods
   - configmaps
   - events


### PR DESCRIPTION
Signed-off-by: clyang82 <chuyang@redhat.com>

I can reproduce the issue that the leaf-hub-status-sync stops work in leaf hub with the following errors:
```
E0411 23:40:27.827425       1 event.go:273] Unable to write event: '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:".16e4fbf5b9d80a94", GenerateName:"", Namespace:"default", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"ConfigMap", Namespace:"", Name:"", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}, Reason:"LeaderElection", Message:"leaf-hub-status-sync-7875f8b99b-sj7sd_48e50b21-33a3-410e-9ff1-9b1c8a72c5df stopped leading", Source:v1.EventSource{Component:"leaf-hub-status-sync-7875f8b99b-sj7sd_48e50b21-33a3-410e-9ff1-9b1c8a72c5df", Host:""}, FirstTimestamp:time.Date(2022, time.April, 11, 23, 39, 56, 327946900, time.Local), LastTimestamp:time.Date(2022, time.April, 11, 23, 39, 56, 327946900, time.Local), Count:1, Type:"Normal", EventTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'Post "https://172.30.0.1:443/api/v1/namespaces/default/events": dial tcp 172.30.0.1:443: connect: connection refused'(may retry after sleeping)
```

That should be a permission issue that it cannot access namespace.